### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
   exclude:
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="3.4.3"
+  allow_failures:
+    - rvm: 1.8.7
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 The puppetversion module for managing the upgrade/downgrade of puppet to a specified version
 
-[![Build Status](https://secure.travis-ci.org/opentable/puppet-puppetversion.png)](https://secure.travis-ci.org/opentable/puppet-puppetversion.png)
+[![Build Status](https://travis-ci.org/opentable/puppet-puppetversion.svg?branch=master)](https://travis-ci.org/opentable/puppet-puppetversion)
 
 ##Module Description
 


### PR DESCRIPTION
In lieu of continuing to have CI builds fail for the dependency issues we're having with 1.8.7, we should change 1.8.7 builds to be allowed to fail.

cc @liamjbennett 