### PR TITLE
Fix Ruby Version Check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class puppetversion(
         require => Package['puppet'],
       }
 
-      if versioncmp($::rubyversion, '2.0.0') <= 0 {
+      if versioncmp($::rubyversion, '2.0.0') >= 0 {
         package { ['pkg-config', 'build-essential', 'libaugeas-dev']:
           ensure => present,
           before => Package['ruby-augeas']


### PR DESCRIPTION
Per the Puppet docs (https://docs.puppetlabs.com/references/latest/function.html#versioncmp), we want to check if `versioncmp` evaluates to 0 or 1 to determine whether to install `ruby-augeas` through RubyGems.

cc @fessyfoo @liamjbennett @yk12OT 