### PR TITLE
Fix gpg key used for puppetlabs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     apt:
-      repo: "https://github.com/bobtfish/puppetlabs-apt"
+      repo: "https://github.com/puppetlabs/puppetlabs-apt"
       ref: master
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     altlib: "https://github.com/opentable/puppet-altlib.git"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class puppetversion(
       apt::source { 'puppetlabs':
         location    => 'http://apt.puppetlabs.com',
         repos       => 'main dependencies',
-        key         => '4BD6EC30',
+        key         => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
         key_content => template('puppetversion/puppetlabs.gpg'),
         require     => Exec['rm_duplicate_puppet_source']
       }

--- a/spec/classes/puppetversion_spec.rb
+++ b/spec/classes/puppetversion_spec.rb
@@ -17,7 +17,7 @@ describe 'puppetversion', :type => :class do
 
     it { should contain_package('puppet-common').with_ensure('3.4.2-1puppetlabs1').that_requires('Apt::Source[puppetlabs]') }
 
-    it { should contain_apt__source('puppetlabs').with_location('http://apt.puppetlabs.com').with_repos('main dependencies').with_key('4BD6EC30').with_key_content(/----BEGIN PGP PUBLIC KEY BLOCK-----/).that_requires('Exec[rm_duplicate_puppet_source]') }
+    it { should contain_apt__source('puppetlabs').with_location('http://apt.puppetlabs.com').with_repos('main dependencies').with_key('47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30').with_key_content(/----BEGIN PGP PUBLIC KEY BLOCK-----/).that_requires('Exec[rm_duplicate_puppet_source]') }
 
     it { should contain_exec('rm_duplicate_puppet_source').with_path('/usr/local/bin:/bin:/usr/bin').with_command('sed -i \'s:deb\ http\:\/\/apt.puppetlabs.com\/ precise main::\' /etc/apt/sources.list').with_onlyif('grep \'deb http://apt.puppetlabs.com/ precise main\' /etc/apt/sources.list') }
 
@@ -53,7 +53,7 @@ describe 'puppetversion', :type => :class do
 
     it { should contain_package('puppet-common').with_ensure('3.4.3-1puppetlabs1').that_requires('Apt::Source[puppetlabs]') }
 
-    it { should contain_apt__source('puppetlabs').with_location('http://apt.puppetlabs.com').with_repos('main dependencies').with_key('4BD6EC30').with_key_content(/----BEGIN PGP PUBLIC KEY BLOCK-----/).that_requires('Exec[rm_duplicate_puppet_source]') }
+    it { should contain_apt__source('puppetlabs').with_location('http://apt.puppetlabs.com').with_repos('main dependencies').with_key('47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30').with_key_content(/----BEGIN PGP PUBLIC KEY BLOCK-----/).that_requires('Exec[rm_duplicate_puppet_source]') }
 
     it { should contain_exec('rm_duplicate_puppet_source').with_path('/usr/local/bin:/bin:/usr/bin').with_command('sed -i \'s:deb\ http\:\/\/apt.puppetlabs.com\/ precise main::\' /etc/apt/sources.list').with_onlyif('grep \'deb http://apt.puppetlabs.com/ precise main\' /etc/apt/sources.list') }
 


### PR DESCRIPTION
This is to rid us of the error:

Warning: /Apt_key[Add key: 4BD6EC30 from Apt::Source puppetlabs]: The id should be a full fingerprint (40 characters), see README.