### PR TITLE
Puppet package name adjustment for ubuntu16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This module is tested on the following platforms:
 * CentOS 7
 * Ubuntu 12.04
 * Ubuntu 14.04
+* Ubuntu 16.04 (puppet3.8.5-2 only)
 * Windows 2008 R2
 * Windows 2012 R2
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,6 @@ class puppetversion(
       }
 
       if $::lsbdistrelease == '16.04' {
-      #if $::operatingsystemmajrelease == '16.04' {
       	$full_version = "${version}"
       }
       else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,8 +64,16 @@ class puppetversion(
         require     => Exec['rm_duplicate_puppet_source'],
       }
 
+      if $::lsbdistrelease == '16.04' {
+      #if $::operatingsystemmajrelease == '16.04' {
+      	$full_version = "${version}"
+      }
+      else {
+      	$full_version = "${version}-1puppetlabs1"
+      }
+	
       package { $puppet_packages:
-        ensure  => "${version}-1puppetlabs1",
+        ensure  => "${full_version}",
         require => Apt::Source['puppetlabs'],
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,14 +65,14 @@ class puppetversion(
       }
 
       if $::lsbdistrelease == '16.04' {
-      	$full_version = "${version}"
+      	$full_version = $version
       }
       else {
       	$full_version = "${version}-1puppetlabs1"
       }
 	
       package { $puppet_packages:
-        ensure  => "${full_version}",
+        ensure  => $full_version,
         require => Apt::Source['puppetlabs'],
       }
 


### PR DESCRIPTION
Puppet package that we have in the Artifactory for Ubuntu16 has no -1puppet1 postfix in the name. 